### PR TITLE
Remove iterator invocation from collection

### DIFF
--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -8,14 +8,11 @@ module ViewComponent
     delegate :format, to: :component
 
     def render_in(view_context, &block)
-      iterator = ActionView::PartialIteration.new(@collection.size)
-
       component.compile(raise_errors: true)
       component.validate_collection_parameter!(validate_default: true)
 
       @collection.map do |item|
         content = component.new(**component_options(item, iterator)).render_in(view_context, &block)
-        iterator.iterate!
         content
       end.join.html_safe
     end


### PR DESCRIPTION
This change removes the invocation of an iterator in `ViewComponent::Collection`. This iterator appears unused but I'm not sure what it's purpose is...